### PR TITLE
Dependency check tooling.

### DIFF
--- a/src/cabal
+++ b/src/cabal
@@ -58,7 +58,9 @@ initialize () {
     [ ! -f "$project.submodules" ] || {
         # submodules initialized if required, the "has it been done before" is pretty crude, but check is useful.
         cat $project.submodules | while read submodule; do
-            find "$submodule" -maxdepth 2 -name \*.cabal
+            if [ -d "$submodule" ]; then
+               find "$submodule" -maxdepth 2 -name \*.cabal
+            fi
         done | grep -q . || (
             cd $(git rev-parse --show-toplevel)
             git submodule init
@@ -119,6 +121,120 @@ run_quick () {
 #
 run_clean () {
     cabal clean
+}
+
+#
+# Dependency tools.
+#
+
+# using this instead of git submodule foreach in the hope I can avoid recursive submodule init/updates (probably can't though, so this may be irrelevant).
+list_modules() {
+    [ $# -eq 1 ] || fail "list_modules requires a single argument, specifying the root of the project."
+    MODULES="$1/.gitmodules"
+    if [ -f "${MODULES}" ]; then
+        grep path "${MODULES}" | sed 's/.*= //'
+    fi
+}
+
+force_sync() {
+    [ $# -eq 1 ] || fail "force sync requires a single argument, specifying the root of the project."
+    SYNC_ROOT="$1"
+    (
+        cd "${SYNC_ROOT}" ## required for submodule commands on older versions of git
+        git fetch
+        git submodule init
+        git submodule update
+        git submodule sync
+    ) > /dev/null 2>&1
+}
+
+run_depend_check () {
+    TOP=$(git rev-parse --show-toplevel)
+    force_sync "${TOP}"
+    list_modules "${TOP}" | while read SUBMODULE; do
+        (
+            cd "${TOP}/${SUBMODULE}"
+            echo "$SUBMODULE"
+            git fetch > /dev/null 2>&1
+            OUT=$(git rev-list --left-right --count origin/master...)
+            BEHIND=$(echo $OUT | awk '{ print $1 }')
+            AHEAD=$(echo $OUT | awk '{ print $2 }')
+
+            if [ "$AHEAD" -eq 0 -a "$BEHIND" -eq 0 ]; then
+                echo '  `- [OK]'
+            elif [ "$AHEAD" -eq 0 -a "$BEHIND" -gt 0 ]; then
+                echo '  `- [WARNING] Behind master.'
+            elif [ "$AHEAD" -gt 0 -a "$BEHIND" -eq 0 ]; then
+                echo '  `- [WARNING] Commits not on master.'
+            elif [ "$AHEAD" -gt 0 -a "$BEHIND" -gt 0 ]; then
+                echo '  `- [WARNING] Commits not on master & behind master.'
+            fi
+        )
+    done
+}
+
+run_depend_deep_check () {
+    TOP=$(git rev-parse --show-toplevel)
+    force_sync "${TOP}"
+    list_modules "${TOP}" | while read SUBMODULE; do
+        (
+            echo "$SUBMODULE"
+            force_sync "${TOP}/${SUBMODULE}"
+            list_modules "${TOP}/${SUBMODULE}" | while read SUBSUBMODULE; do
+                if [ -e "${TOP}/${SUBSUBMODULE}" ]; then
+                    NESTED=$(cd "${TOP}/${SUBMODULE}/${SUBSUBMODULE}" > /dev/null 2>&1; git rev-parse HEAD);
+                    OUTER=$(cd "${TOP}/${SUBSUBMODULE}" > /dev/null 2>&1; git rev-parse HEAD);
+                    if [ "${NESTED}" = "${OUTER}" ]; then
+                        echo "  \`- [OK] ${SUBSUBMODULE}"
+                    else
+                        (
+                            cd "${TOP}/${SUBSUBMODULE}"
+                            git fetch > /dev/null 2>&1
+                            echo ${TOP}/${SUBSUBMODULE}
+                            OUT=$(git rev-list --left-right --count "${NESTED}...${OUTER}")
+                            BEHIND=$(echo $OUT | awk '{ print $1 }')
+                            AHEAD=$(echo $OUT | awk '{ print $2 }')
+                            echo "  \`- [WARNING] ${SUBSUBMODULE} is out of sync, outer commit ${OUTER}, nested ${NESTED}, outer is ${BEHIND} commits behind, ${AHEAD} commits ahead."
+                        )
+                    fi
+                else
+                    echo "  \`- [WARNING] Potentially missing dependency ${SUBSUBMODULE}"
+                fi
+            done
+        )
+    done
+}
+
+run_depend_sync () {
+    TOP=$(git rev-parse --show-toplevel)
+    list_modules "${TOP}" | while read SUBMODULE; do
+        (
+            echo "$SUBMODULE"
+            force_sync "${TOP}/${SUBMODULE}"
+
+            cd "${TOP}/${SUBMODULE}"
+            if git branch -a | grep -q origin/ambiata; then
+                git checkout ambiata
+                git merge origin/ambiata
+            else
+                git checkout master
+                git merge origin/master
+            fi
+
+            force_sync "${TOP}/${SUBMODULE}"
+        )
+    done
+}
+
+run_depend () {
+    [ $# -eq 1 ] || fail "Quick requires a single argument, specifying the mod as one of [check|deep-check|sync]."
+
+    case "$1" in
+    check) run_depend_check ;;
+    deep-check) run_depend_deep_check ;;
+    sync) run_depend_sync;;
+    *) fail "Unknown mode [$1], expected one of [check|deep-check|sync]" ;;
+    esac
 }
 
 #
@@ -188,6 +304,6 @@ esac
 
 MODE="$1"; shift
 case "$MODE" in
-build|test|repl|quick|demo|exec|tags|lint|init|update|clean) run_$MODE "$@" ;;
+build|test|repl|quick|demo|exec|tags|lint|init|update|clean|depend) run_$MODE "$@" ;;
 *) fail "Unknown mode: $MODE"
 esac

--- a/src/cabal
+++ b/src/cabal
@@ -238,10 +238,10 @@ run_depend () {
 }
 
 #
-# Run hasktags on this project (building hlint if necessary).
+# Run hasktags on this project.
 #
 run_tags () {
-    # should install hasktags if it doesn't exist yet.
+    # TODO should install hasktags if it doesn't exist yet.
     hasktags -e src test main
 }
 
@@ -249,9 +249,8 @@ run_tags () {
 # Run hlint on this project (building hlint if necessary).
 #
 run_lint () {
-    # do something with hlint - need to work out best convention to build up
-    echo "Someone should really implement this."
-    exit 1
+    # TODO should install hlint if it doesn't exist yet.
+    hlint src test main
 }
 
 #

--- a/src/cabal
+++ b/src/cabal
@@ -18,6 +18,7 @@ Commands:
     init            Start a new project.
     update          Cabal update, but limited to retrieving at most once per day.
     clean           Remove compiled artifacts.
+    depend          Dependency organisation tooling check|deep-check|sync.
 EOF
     exit ${status}
 }

--- a/src/cabal
+++ b/src/cabal
@@ -108,7 +108,7 @@ run_repl () {
 #
 run_quick () {
     initialize
-    [ $# -eq 1 ] || fail "Quick requires a single argument, specifying the entry point you want to load."
+    [ $# -eq 1 ] || fail "'quick' requires a single argument, specifying the entry point you want to load."
     [ -f "$1" ] || fail "The entry point does not exist."
     [ ! -d src ] || SRC_DIRS="-isrc"
     [ ! -d test ] || SRC_DIRS="${SRC_DIRS:-} -itest"
@@ -128,7 +128,7 @@ run_clean () {
 #
 
 # using this instead of git submodule foreach in the hope I can avoid recursive submodule init/updates (probably can't though, so this may be irrelevant).
-list_modules() {
+list_modules () {
     [ $# -eq 1 ] || fail "list_modules requires a single argument, specifying the root of the project."
     MODULES="$1/.gitmodules"
     if [ -f "${MODULES}" ]; then
@@ -136,7 +136,7 @@ list_modules() {
     fi
 }
 
-force_sync() {
+force_sync () {
     [ $# -eq 1 ] || fail "force sync requires a single argument, specifying the root of the project."
     SYNC_ROOT="$1"
     (
@@ -227,7 +227,7 @@ run_depend_sync () {
 }
 
 run_depend () {
-    [ $# -eq 1 ] || fail "Quick requires a single argument, specifying the mod as one of [check|deep-check|sync]."
+    [ $# -eq 1 ] || fail "'depend' requires a single argument, specifying the mode as one of [check|deep-check|sync]."
 
     case "$1" in
     check) run_depend_check ;;

--- a/src/cabal
+++ b/src/cabal
@@ -238,22 +238,6 @@ run_depend () {
 }
 
 #
-# Build and run the configured demonstration executable.
-#
-run_demo () {
-    echo "Someone should really implement this."
-    exit 1
-}
-
-#
-# Build and run the configured application executable.
-#
-run_exec () {
-    echo "Someone should really implement this."
-    exit 1
-}
-
-#
 # Run hasktags on this project (building hlint if necessary).
 #
 run_tags () {
@@ -266,15 +250,6 @@ run_tags () {
 #
 run_lint () {
     # do something with hlint - need to work out best convention to build up
-    echo "Someone should really implement this."
-    exit 1
-}
-
-#
-# Initialize an empty project with a reasonable skeleton.
-#
-run_init () {
-    # make sure there is an empty directory and fill out skeleton
     echo "Someone should really implement this."
     exit 1
 }
@@ -304,6 +279,6 @@ esac
 
 MODE="$1"; shift
 case "$MODE" in
-build|test|repl|quick|demo|exec|tags|lint|init|update|clean|depend) run_$MODE "$@" ;;
+build|test|repl|quick|tags|lint|update|clean|depend) run_$MODE "$@" ;;
 *) fail "Unknown mode: $MODE"
 esac

--- a/src/cabal
+++ b/src/cabal
@@ -222,6 +222,7 @@ run_depend_sync () {
                 git merge origin/master
             fi
 
+            force_sync "${TOP}/${SUBMODULE}"
         )
     done
 }

--- a/src/cabal
+++ b/src/cabal
@@ -222,7 +222,6 @@ run_depend_sync () {
                 git merge origin/master
             fi
 
-            force_sync "${TOP}/${SUBMODULE}"
         )
     done
 }


### PR DESCRIPTION
This is pretty random, and I am not really even suggesting we merge it. But given the few conversations on the topic in the last few days I thought I would throw this up there. This is basically an encoding of what I normally do interactively to check/sync dependencies.

There are three commands 
 - `./cabal depend check` which gives basic status of whether each submodule is on master and how far behind it is.
 - `./cabal depend deep-check` which compares nested submodules for consistency.
 - `./cabal depend sync` very crude force direct submodules to latest version.

If people find these useful, maybe someone can give it a bit more polish, but just throwing it out there for now. I think there are obvious better solutions (discussion around driving things off anatomy and github api in a way that doesn't have to download the world to check etc..., but they will all take longer than the 20 minutes spent on this.