### PR TITLE
Improved behaviour for Setup.hs.

### DIFF
--- a/src/Setup.hs
+++ b/src/Setup.hs
@@ -23,6 +23,9 @@ main =
      preConf = \args flags -> do
        createDirectoryIfMissingVerbose silent True "gen"
        (preConf hooks) args flags
+   , sDistHook  = \pd mlbi uh flags -> do
+       genBuildInfo silent pd
+       (sDistHook hooks) pd mlbi uh flags
    , buildHook = \pd lbi uh flags -> do
        genBuildInfo (fromFlag $ buildVerbosity flags) pd
        (buildHook hooks) pd lbi uh flags

--- a/src/Setup.hs
+++ b/src/Setup.hs
@@ -20,25 +20,28 @@ main :: IO ()
 main =
   let hooks = simpleUserHooks
    in defaultMainWithHooks hooks {
-     buildHook = \pd lbi uh flags -> do
-       genBuildInfo (fromFlag $ buildVerbosity flags) pd lbi
+     preConf = \args flags -> do
+       createDirectoryIfMissingVerbose silent True "gen"
+       (preConf hooks) args flags
+   , buildHook = \pd lbi uh flags -> do
+       genBuildInfo (fromFlag $ buildVerbosity flags) pd
        (buildHook hooks) pd lbi uh flags
    , replHook = \pd lbi uh flags args -> do
-       genBuildInfo (fromFlag $ replVerbosity flags) pd lbi
+       genBuildInfo (fromFlag $ replVerbosity flags) pd
        (replHook hooks) pd lbi uh flags args
    , testHook = \args pd lbi uh flags -> do
-       genBuildInfo (fromFlag $ testVerbosity flags) pd lbi 
+       genBuildInfo (fromFlag $ testVerbosity flags) pd
        (testHook hooks) args pd lbi uh flags
    }
 
-genBuildInfo :: Verbosity -> PackageDescription -> LocalBuildInfo -> IO ()
-genBuildInfo verbosity pkg info = do
-  createDirectoryIfMissingVerbose verbosity True (autogenModulesDir info)
+genBuildInfo :: Verbosity -> PackageDescription -> IO ()
+genBuildInfo verbosity pkg = do
+  createDirectoryIfMissingVerbose verbosity True "gen"
   let (PackageName pname) = pkgName . package $ pkg
       version = pkgVersion . package $ pkg
       name = "BuildInfo_" ++ (map (\c -> if c == '-' then '_' else c) pname)
-      targetHs = autogenModulesDir info </> name <.> "hs"
-      targetText = autogenModulesDir info </> "version.txt"
+      targetHs = "gen" </> name <.> "hs"
+      targetText = "gen" </> "version.txt"
   t <- timestamp
   gv <- gitVersion
   let v = showVersion version

--- a/src/cabal
+++ b/src/cabal
@@ -160,6 +160,7 @@ run_quick () {
     [ -f "$1" ] || fail "The entry point does not exist."
     [ ! -d src ] || SRC_DIRS="-isrc"
     [ ! -d test ] || SRC_DIRS="${SRC_DIRS:-} -itest"
+    [ ! -d gen ] || SRC_DIRS="${SRC_DIRS:-} -igen"
     [ ! -d dist/build/autogen ] || SRC_DIRS="${SRC_DIRS:-} -idist/build/autogen"
     ghci -package-db=$(find .cabal-sandbox -name '*-packages.conf.d') ${SRC_DIRS:-} "$1"
 }
@@ -174,6 +175,7 @@ run_watch () {
     [ -f "$1" ] || fail "The entry point does not exist."
     [ ! -d src ] || SRC_DIRS="-isrc"
     [ ! -d test ] || SRC_DIRS="${SRC_DIRS:-} -itest"
+    [ ! -d gen ] || SRC_DIRS="${SRC_DIRS:-} -igen"
     [ ! -d dist/build/autogen ] || SRC_DIRS="${SRC_DIRS:-} -idist/build/autogen"
     ENTRY=$1
     shift


### PR DESCRIPTION
This moves generated files into their own src dir, instead
of the autogen directory. This means the src can is constructed
ahead of time - allowing sdist, and re-exporting of the
generated module to work as expected.

This change requires consumers to make a couple of changes
 - Add gen as a src dir
 - Add gen to .gitignore or equiv