### PR TITLE
Pass through arguments on build.

### DIFF
--- a/src/cabal
+++ b/src/cabal
@@ -124,7 +124,7 @@ initialize () {
 #
 run_build () {
     initialize
-    cabal build --ghc-option="-Werror"
+    cabal build --ghc-option="-Werror" "$@"
 }
 
 #


### PR DESCRIPTION
I think this is just an oversight. Useful when you have lots of executables and you want to build one.