### PR TITLE
Ignore errors from delete-source which oftens fails

### DIFF
--- a/src/cabal
+++ b/src/cabal
@@ -101,7 +101,8 @@ initialize () {
       source_path=$(echo $source | sed s#${PROJECT_ROOT}/##)
       if ! $(echo "${CABAL_SOURCES}" | grep -q "${source_path}"); then
         echo "${source_path} no longer exists - removing from the sandbox"
-        cabal sandbox delete-source "$source" 1> /dev/null
+        # This will fail if there are any remaining non-existent sources
+        cabal sandbox delete-source "$source" 1> /dev/null || true
       fi
     done
 


### PR DESCRIPTION
Not sure if other people see this. Let me know if there's a better way. I'm still not actually sure doing the delete-source is solving the problem well enough at the moment.