### PR TITLE
Add reorder-goals and max-backjumps to cabal install

### DIFF
--- a/src/cabal
+++ b/src/cabal
@@ -153,7 +153,7 @@ initialize () {
     done
 
     # all dependencies installed, and configure been run?
-    cabal install -j --only-dependencies --force-reinstalls --enable-tests --enable-benchmarks
+    cabal install -j --only-dependencies --force-reinstalls --enable-tests --enable-benchmarks --reorder-goals --max-backjumps=-1
     cabal configure --enable-tests --enable-benchmarks $CABAL_CONFIG_ARGS
 }
 


### PR DESCRIPTION
This is the default in `mafia` (and `stack`). It helps in some cases, both with error messages and actually building, but can make things slower by default.

I'm opening this to gauge feedback. Is this the right default?

/cc @jystic (and @raronson this is what you just hit)