### PR TITLE
Add dependency info

### DIFF
--- a/src/Setup.hs
+++ b/src/Setup.hs
@@ -5,13 +5,15 @@ import           Data.List (intercalate)
 import           Data.Monoid ((<>))
 import           Data.Version (showVersion)
 
+import           Distribution.InstalledPackageInfo
 import           Distribution.PackageDescription
-import           Distribution.Verbosity
 import           Distribution.Simple
 import           Distribution.Simple.Setup (BuildFlags(..), ReplFlags(..), TestFlags(..), fromFlag)
 import           Distribution.Simple.LocalBuildInfo
+import           Distribution.Simple.PackageIndex
 import           Distribution.Simple.BuildPaths (autogenModulesDir)
 import           Distribution.Simple.Utils (createDirectoryIfMissingVerbose, rewriteFile, rawSystemStdout)
+import           Distribution.Verbosity
 
 main :: IO ()
 main =
@@ -25,12 +27,15 @@ main =
        (sDistHook hooks) pd mlbi uh flags
    , buildHook = \pd lbi uh flags -> do
        genBuildInfo (fromFlag $ buildVerbosity flags) pd
+       genDependencyInfo pd lbi
        (buildHook hooks) pd lbi uh flags
    , replHook = \pd lbi uh flags args -> do
        genBuildInfo (fromFlag $ replVerbosity flags) pd
+       genDependencyInfo pd lbi
        (replHook hooks) pd lbi uh flags args
    , testHook = \args pd lbi uh flags -> do
        genBuildInfo (fromFlag $ testVerbosity flags) pd
+       genDependencyInfo pd lbi
        (testHook hooks) args pd lbi uh flags
    }
 
@@ -56,6 +61,28 @@ genBuildInfo verbosity pkg = do
     , "buildInfoVersion = \"" ++ buildVersion ++ "\""
     ]
   rewriteFile targetText buildVersion
+
+genDependencyInfo :: PackageDescription -> LocalBuildInfo -> IO ()
+genDependencyInfo pkg info = do
+  let
+    (PackageName pname) = pkgName . package $ pkg
+    name = "DependencyInfo_" ++ (map (\c -> if c == '-' then '_' else c) pname)
+    targetHs = autogenModulesDir info ++ "/" ++ name ++ ".hs"
+    render p =
+      let
+        n = unPackageName $ pkgName p
+        v = intercalate "." . fmap show . versionBranch $ pkgVersion p
+      in
+       n ++ "-" ++ v
+    deps = fmap (render . sourcePackageId) . allPackages $ installedPkgs info
+    strs = flip fmap deps $ \d -> "\"" ++ d ++ "\""
+
+  rewriteFile targetHs $ unlines [
+      "module " ++ name ++ " where"
+    , "import Prelude"
+    , "dependencyInfo :: [String]"
+    , "dependencyInfo = [\n    " ++ intercalate "\n  , " strs ++ "\n  ]"
+    ]
 
 gitVersion :: Verbosity -> IO String
 gitVersion verbosity = do


### PR DESCRIPTION
To export the dependencies used to build binaries 

Example output

```
module DependencyInfo_ambiata_foo where
import Prelude
dependencyInfo :: [String]
dependencyInfo = [
    "QuickCheck-2.7.6"
  , "StateVar-1.1.0.4"
  ]
```