### PR TITLE
Cabal-2.0.x makes PackageName an opaque type

### DIFF
--- a/src/Setup.hs
+++ b/src/Setup.hs
@@ -43,7 +43,7 @@ main =
 genBuildInfo :: Verbosity -> PackageDescription -> IO ()
 genBuildInfo verbosity pkg = do
   createDirectoryIfMissingVerbose verbosity True "gen"
-  let (PackageName pname) = pkgName . package $ pkg
+  let pname = unPackageName . pkgName . package $ pkg
       version = pkgVersion . package $ pkg
       name = "BuildInfo_" ++ (map (\c -> if c == '-' then '_' else c) pname)
       targetHs = "gen/" ++ name ++ ".hs"
@@ -66,7 +66,7 @@ genBuildInfo verbosity pkg = do
 genDependencyInfo :: Verbosity -> PackageDescription -> LocalBuildInfo -> IO ()
 genDependencyInfo verbosity pkg info = do
   let
-    (PackageName pname) = pkgName . package $ pkg
+    pname = unPackageName . pkgName . package $ pkg
     name = "DependencyInfo_" ++ (map (\c -> if c == '-' then '_' else c) pname)
     targetHs = autogenModulesDir info ++ "/" ++ name ++ ".hs"
     render p =


### PR DESCRIPTION
Just FYI, if anyone runs in to problems with `PackageName` not being visible, it's because `Cabal-2.0.0.2` is being pulled in, a temporary fix is to pin the Cabal version to something < 2.0 in the mafia lock file.

The alternative is to update the `Setup.hs` with this change, but that's not really practical to apply across our whole ecosystem at once.

! @nhibberd @charleso @novemberkilo 
/jury approved @charleso @novemberkilo @nhibberd @tmcgilchrist