### PR TITLE
Setup.hs: Updates for ghc-8.2 and Cabal 2.0

### DIFF
--- a/src/Setup.hs
+++ b/src/Setup.hs
@@ -1,20 +1,43 @@
-#!/usr/bin/env runhaskell
+{-# LANGUAGE CPP #-}
 
-import           Data.Char (isDigit, toLower)
-import           Data.Function (on)
-import           Data.List (intercalate, sortBy)
+import           Data.Char (isDigit)
+import           Data.List (intercalate)
 import           Data.Monoid ((<>))
-import           Data.Version (showVersion)
 
 import           Distribution.InstalledPackageInfo
 import           Distribution.PackageDescription
-import           Distribution.Simple
+import           Distribution.Simple (buildHook, defaultMainWithHooks, pkgName, pkgVersion, preConf, replHook, sDistHook, simpleUserHooks, testHook)
 import           Distribution.Simple.Setup (BuildFlags(..), ReplFlags(..), TestFlags(..), fromFlag)
 import           Distribution.Simple.LocalBuildInfo
 import           Distribution.Simple.PackageIndex
-import           Distribution.Simple.BuildPaths (autogenModulesDir)
 import           Distribution.Simple.Utils (createDirectoryIfMissingVerbose, rewriteFile, rawSystemStdout)
 import           Distribution.Verbosity
+
+#if __GLASGOW_HASKELL__ <= 710
+-- GHC 7.10 and earlier do not support the MIN_VERSION_Cabal macro.
+#define MIN_VERSION_Cabal(a,b,c) 0
+#endif
+
+#if MIN_VERSION_Cabal(2,0,0)
+import           Distribution.Types.PackageName (PackageName, unPackageName)
+import           Distribution.Simple.BuildPaths (autogenPackageModulesDir)
+import           Distribution.Version (Version, versionNumbers)
+
+showVersion :: Version -> String
+showVersion = intercalate "." . fmap show . versionNumbers
+
+autogenModulesDirCompat :: LocalBuildInfo -> String
+autogenModulesDirCompat = autogenPackageModulesDir
+
+#else
+import           Distribution.Simple (PackageName, unPackageName)
+import           Distribution.Simple.BuildPaths (autogenModulesDir)
+import           Data.Version (showVersion)
+
+autogenModulesDirCompat :: LocalBuildInfo -> String
+autogenModulesDirCompat = autogenModulesDir
+#endif
+
 
 main :: IO ()
 main =
@@ -68,18 +91,17 @@ genDependencyInfo verbosity pkg info = do
   let
     pname = unPackageName . pkgName . package $ pkg
     name = "DependencyInfo_" ++ (map (\c -> if c == '-' then '_' else c) pname)
-    targetHs = autogenModulesDir info ++ "/" ++ name ++ ".hs"
+    targetHs = autogenModulesDirCompat info ++ "/" ++ name ++ ".hs"
     render p =
       let
         n = unPackageName $ pkgName p
-        v = intercalate "." . fmap show . versionBranch $ pkgVersion p
+        v = showVersion $ pkgVersion p
       in
        n ++ "-" ++ v
     deps = fmap (render . sourcePackageId) . allPackages $ installedPkgs info
-    sdeps = sortBy (compare `on` fmap toLower) deps
-    strs = flip fmap sdeps $ \d -> "\"" ++ d ++ "\""
+    strs = flip fmap deps $ \d -> "\"" ++ d ++ "\""
 
-  createDirectoryIfMissingVerbose verbosity True (autogenModulesDir info)
+  createDirectoryIfMissingVerbose verbosity True (autogenModulesDirCompat info)
 
   rewriteFile targetHs $ unlines [
       "module " ++ name ++ " where"


### PR DESCRIPTION
Tested with GHC 7.10, 8.0 and 8.2.
    
Because this script is run with `runhaskell` it is not possible
to use the normal cabal `MIN_VERSION_<pkg>` macros and have to
rely on GHC version information instead.

! @charleso @jystic @nhibberd 
/jury approved @charleso